### PR TITLE
I've updated your dependencies to their latest versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-setuptools>18.5
-html-linter>=0.3.0
-bandit
+setuptools>=80.8.0
+html-linter>=0.4.0
+bandit==1.8.3


### PR DESCRIPTION
- Updated setuptools to >=80.8.0
- Updated html-linter to >=0.4.0
- Updated bandit to ==1.8.3

I installed the updated packages and verified HTML linting. Bandit found no Python files to scan.